### PR TITLE
build[vx-660]: Add an optional `pathPrefix` to `ingress`

### DIFF
--- a/charts/service/Chart.yaml
+++ b/charts/service/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: allstar-service
-version: 1.0.8
-appVersion: 1.0.8
+version: 1.0.9
+appVersion: 1.0.9

--- a/charts/service/Chart.yaml
+++ b/charts/service/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: allstar-service
-version: 1.0.7
-appVersion: 1.0.7
+version: 1.0.9
+appVersion: 1.0.9

--- a/charts/service/templates/ingressroute.yaml
+++ b/charts/service/templates/ingressroute.yaml
@@ -11,7 +11,7 @@ spec:
     - websecure
   routes:
     - kind: Rule
-      match: "Host(`{{ .Release.Name }}.{{ .Values.env }}.allstar.dev`){{ range $hostname := .Values.ingress.hostnames }} || Host(`{{ $hostname }}`){{ end }}"
+      match: "(Host(`{{ .Release.Name }}.{{ .Values.env }}.allstar.dev`){{ range $hostname := .Values.ingress.hostnames }} || Host(`{{ $hostname }}`){{ end }}){{ if .Values.ingress.pathPrefix }} && PathPrefix(`{{ .Values.ingress.pathPrefix }}`){{ end }}"
       services:
         - name: {{ .Release.Name }}
           port: {{ .Values.port }}

--- a/charts/service/values.yaml
+++ b/charts/service/values.yaml
@@ -13,6 +13,7 @@ service:
 
 ingress:
   enabled: false
+  pathPrefix: null
   hostnames: []
 
 resources:


### PR DESCRIPTION
This will allow filtering of traffic to the same hostname based on path prefix. So we can send `/graphql` traffic to Rubin and `/oauth` traffic to Kanye (for example).