### PR TITLE
build[vx-677]: Add HPA to shared helm chart (optional, off by default)

### DIFF
--- a/charts/service/Chart.yaml
+++ b/charts/service/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: allstar-service
-version: 1.0.9
-appVersion: 1.0.9
+version: 1.1.0
+appVersion: 1.1.0

--- a/charts/service/templates/autoscaler.yaml
+++ b/charts/service/templates/autoscaler.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.autoscaling.enabled }}
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ .Release.Name }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ .Release.Name }}
+  minReplicas: {{ .Values.autoscaling.replicas.min }}
+  maxReplicas: {{ .Values.autoscaling.replicas.max }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.averageUtilization.cpu }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.averageUtilization.memory }}
+{{- end }}

--- a/charts/service/values.yaml
+++ b/charts/service/values.yaml
@@ -4,6 +4,15 @@ image: ""
 port: 3000
 federationSchemaPublishCommand: null
 
+autoscaling:
+  enabled: false
+  replicas:
+    min: 2
+    max: 10
+  averageUtilization:
+    cpu: 80
+    memory: 80
+
 externalSecret:
   enabled: true
 


### PR DESCRIPTION
Also since there's a semver style version number associated with the chart we should really use semver standards I realize. This is a backward compatible feature so bumping the minor version number.