### PR TITLE
feat[vx-652]: Add `ServiceMonitor` template for prometheus scraping

### DIFF
--- a/charts/service/Chart.yaml
+++ b/charts/service/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: allstar-service
-version: 1.1.0
-appVersion: 1.1.0
+version: 1.2.0
+appVersion: 1.2.0

--- a/charts/service/templates/service.yaml
+++ b/charts/service/templates/service.yaml
@@ -4,6 +4,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Release.Name }}
+  labels:
+    app: {{ .Release.Name }}
 spec:
   type: {{ .Values.service.type }}
   selector:

--- a/charts/service/templates/service_monitor.yaml
+++ b/charts/service/templates/service_monitor.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/monitoring.coreos.com/servicemonitor_v1.json
+{{- if .Values.monitoring.enabled }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ .Release.Name }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}
+  endpoints:
+    - port: http
+{{- end }}

--- a/charts/service/values.yaml
+++ b/charts/service/values.yaml
@@ -13,6 +13,9 @@ autoscaling:
     cpu: 80
     memory: 80
 
+monitoring:
+  enabled: false
+
 externalSecret:
   enabled: true
 


### PR DESCRIPTION
`ServiceMonitor` and `PodMonitor` are CRD resources that are part of Prometheus monitoring. This is a very simple version where we're just telling Prometheus to use the existing service to discover pods to scrape for metrics. This all used to be done via annotations on the pod (you'd add a `prometheus.io/port`, `prometheus.io/path`, etc. annotation to the pod to tell Prometheus where to scrape metrics) but this is the new way of doing it. Comes with some advantages like the ability to remap metrics via the monitor (add a prefix to all scraped metrics, filter certain metrics out of scraping, modify the labels of scraped metrics, etc).