### PR TITLE
build[vx-654]: Make it possible to have multiple containers in the deployment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release charts
 
 on:
   push:
-    branches: [main]
+    branches: [main, ross/vx-654-add-prometheus-metrics-to-accountant]
 
 jobs:
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release charts
 
 on:
   push:
-    branches: [main, ross/vx-654-add-prometheus-metrics-to-accountant]
+    branches: [main]
 
 jobs:
   release:

--- a/charts/service/Chart.yaml
+++ b/charts/service/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: allstar-service
-version: 2.0.0
-appVersion: 2.0.0
+version: 2.0.0-beta1
+appVersion: 2.0.0-beta1

--- a/charts/service/Chart.yaml
+++ b/charts/service/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: allstar-service
-version: 2.0.0-beta3
-appVersion: 2.0.0-beta3
+version: 2.0.0-beta4
+appVersion: 2.0.0-beta4

--- a/charts/service/Chart.yaml
+++ b/charts/service/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: allstar-service
-version: 2.0.0-beta1
-appVersion: 2.0.0-beta1
+version: 2.0.0-beta2
+appVersion: 2.0.0-beta2

--- a/charts/service/Chart.yaml
+++ b/charts/service/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: allstar-service
-version: 2.0.0-beta4
-appVersion: 2.0.0-beta4
+version: 2.0.0-beta5
+appVersion: 2.0.0-beta5

--- a/charts/service/Chart.yaml
+++ b/charts/service/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: allstar-service
-version: 2.0.0-beta5
-appVersion: 2.0.0-beta5
+version: 2.0.0
+appVersion: 2.0.0

--- a/charts/service/Chart.yaml
+++ b/charts/service/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: allstar-service
-version: 1.2.1
-appVersion: 1.2.1
+version: 2.0.0
+appVersion: 2.0.0

--- a/charts/service/Chart.yaml
+++ b/charts/service/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: allstar-service
-version: 2.0.0-beta2
-appVersion: 2.0.0-beta2
+version: 2.0.0-beta3
+appVersion: 2.0.0-beta3

--- a/charts/service/templates/deployment.yaml
+++ b/charts/service/templates/deployment.yaml
@@ -23,6 +23,16 @@ spec:
       containers:
       {{- range $name, $container := .Values.deployment.containers }}
       - name: {{ $name }}
+        {{- if $container.command }}
+        {{- if kindIs "slice" $container.command }}
+        command:
+        {{- range $el := $container.command }}
+        - {{ $el }}
+        {{- end }}
+        {{- else }}
+        command: {{ $container.command }}
+        {{- end }}
+        {{- end }}
         image: {{ $.Values.image }}
         {{- if $container.resources }}
         resources:

--- a/charts/service/templates/deployment.yaml
+++ b/charts/service/templates/deployment.yaml
@@ -21,55 +21,59 @@ spec:
       serviceAccount: {{ .Values.serviceAccount }}
       {{- end }}
       containers:
-      - name: {{ .Release.Name }}
-        image: {{ .Values.image }}
-        {{- if .Values.resources }}
+      {{- range $name, $container := .Values.deployment.containers }}
+      - name: {{ $name }}
+        image: {{ $.Values.image }}
+        {{- if $container.resources }}
         resources:
-          {{- if .Values.resources.requests }}
+          {{- if $container.resources.requests }}
           requests:
-            {{- range $k, $v := .Values.resources.requests }}
+            {{- range $k, $v := $container.resources.requests }}
             {{ $k }}: {{ $v }}
             {{- end }}
           {{- end }}
-          {{- if .Values.resources.limits }}
+          {{- if $container.resources.limits }}
           limits:
-            {{- range $k, $v := .Values.resources.limits }}
+            {{- range $k, $v := $container.resources.limits }}
             {{ $k }}: {{ $v }}
             {{- end }}
           {{- end }}
         {{- end }}
         env:
-        - name: PORT
-          value: {{ .Values.port | quote }}
         - name: K8S_ENV
-          value: {{ .Values.env }}
-        {{- range $k, $v := .Values.configMapEnv }}
+          value: {{ $.Values.env }}
+        {{- range $k, $v := $container.configMapEnv }}
         - name: {{ $k }}
           valueFrom:
             configMapKeyRef:
               name: {{ $.Release.Name }}
               key: {{ $v }}
         {{- end }}
-        {{- range $k, $v := .Values.secretEnv }}
+        {{- range $k, $v := $container.secretEnv }}
         - name: {{ $k }}
           valueFrom:
             secretKeyRef:
               name: {{ $.Release.Name }}
               key: {{ $v }}
         {{- end }}
-        {{- range $k, $v := .Values.staticEnv }}
+        {{- range $k, $v := $container.staticEnv }}
         - name: {{ $k }}
           value: "{{ $v }}"
         {{- end }}
+        {{- if $container.ports }}
         ports:
-        - name: http
-          containerPort: {{ .Values.port }}
-        {{- if .Values.startupProbe }}
-        startupProbe: {{- include "probe" (set .Values.startupProbe "port" .Values.port)  | indent 10 }}
+        {{- range $k, $v := $container.ports }}
+        - name: {{ $k }}
+          containerPort: {{ $v }}
         {{- end }}
-        {{- if .Values.livenessProbe }}
-        livenessProbe: {{- include "probe" (set .Values.livenessProbe "port" .Values.port)  | indent 10 }}
         {{- end }}
-        {{- if .Values.readinessProbe }}
-        readinessProbe: {{- include "probe" (set .Values.readinessProbe "port" .Values.port)  | indent 10 }}
+        {{- if $container.startupProbe }}
+        startupProbe: {{- include "probe" $container.startupProbe  | indent 10 }}
         {{- end }}
+        {{- if $container.livenessProbe }}
+        livenessProbe: {{- include "probe" $container.livenessProbe  | indent 10 }}
+        {{- end }}
+        {{- if $container.readinessProbe }}
+        readinessProbe: {{- include "probe" $container.readinessProbe | indent 10 }}
+        {{- end }}
+      {{- end }}

--- a/charts/service/templates/schema_publish.yaml
+++ b/charts/service/templates/schema_publish.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.federationSchemaPublishCommand }}
+{{- if .Values.federationSchemaPublish.command }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -20,25 +20,25 @@ spec:
         command:
           - "/bin/sh"
           - "-xec"
-          - "{{ .Values.federationSchemaPublishCommand }}"
+          - "{{ .Values.federationSchemaPublish.command }}"
         env:
         - name: K8S_ENV
           value: {{ .Values.env }}
-        {{- range $k, $v := .Values.deployment.containers.default.configMapEnv }}
+        {{- range $k, $v := .Values.federationSchemaPublish.configMapEnv }}
         - name: {{ $k }}
           valueFrom:
             configMapKeyRef:
               name: {{ $.Release.Name }}
               key: {{ $v }}
         {{- end }}
-        {{- range $k, $v := .Values.deployment.containers.default.secretEnv }}
+        {{- range $k, $v := .Values.federationSchemaPublish.secretEnv }}
         - name: {{ $k }}
           valueFrom:
             secretKeyRef:
               name: {{ $.Release.Name }}
               key: {{ $v }}
         {{- end }}
-        {{- range $k, $v := .Values.deployment.containers.default.staticEnv }}
+        {{- range $k, $v := .Values.federationSchemaPublish.staticEnv }}
         - name: {{ $k }}
           value: "{{ $v }}"
         {{- end }}

--- a/charts/service/templates/schema_publish.yaml
+++ b/charts/service/templates/schema_publish.yaml
@@ -17,45 +17,28 @@ spec:
       containers:
       - name: {{ .Release.Name }}
         image: {{ .Values.image }}
-        {{- if .Values.resources }}
-        resources:
-          {{- if .Values.resources.requests }}
-          requests:
-            {{- range $k, $v := .Values.resources.requests }}
-            {{ $k }}: {{ $v }}
-            {{- end }}
-          {{- end }}
-          {{- if .Values.resources.limits }}
-          limits:
-            {{- range $k, $v := .Values.resources.limits }}
-            {{ $k }}: {{ $v }}
-            {{- end }}
-          {{- end }}
-        {{- end }}
         command:
           - "/bin/sh"
           - "-xec"
           - "{{ .Values.federationSchemaPublishCommand }}"
         env:
-        - name: PORT
-          value: {{ .Values.port | quote }}
         - name: K8S_ENV
           value: {{ .Values.env }}
-        {{- range $k, $v := .Values.configMapEnv }}
+        {{- range $k, $v := .Values.deployment.containers.default.configMapEnv }}
         - name: {{ $k }}
           valueFrom:
             configMapKeyRef:
               name: {{ $.Release.Name }}
               key: {{ $v }}
         {{- end }}
-        {{- range $k, $v := .Values.secretEnv }}
+        {{- range $k, $v := .Values.deployment.containers.default.secretEnv }}
         - name: {{ $k }}
           valueFrom:
             secretKeyRef:
               name: {{ $.Release.Name }}
               key: {{ $v }}
         {{- end }}
-        {{- range $k, $v := .Values.staticEnv }}
+        {{- range $k, $v := .Values.deployment.containers.default.staticEnv }}
         - name: {{ $k }}
           value: "{{ $v }}"
         {{- end }}

--- a/charts/service/templates/service.yaml
+++ b/charts/service/templates/service.yaml
@@ -11,7 +11,11 @@ spec:
   selector:
     service: {{ .Release.Name }}
   ports:
-  - name: http
-    port: {{ .Values.port }}
-    targetPort: {{ .Values.port }}
+  {{- range $k, $container := .Values.deployment.containers }}
+  {{- range $name, $port := $container.ports }}
+  - name: {{ $name }}
+    port: {{ $port }}
+    targetPort: {{ $port }}
+  {{- end }}
+  {{- end }}
 {{- end }}

--- a/charts/service/templates/service_monitor.yaml
+++ b/charts/service/templates/service_monitor.yaml
@@ -10,5 +10,5 @@ spec:
     matchLabels:
       app: {{ .Release.Name }}
   endpoints:
-    - port: http
+    - port: {{ .Values.monitoring.port }}
 {{- end }}

--- a/charts/service/values.yaml
+++ b/charts/service/values.yaml
@@ -1,7 +1,6 @@
 ---
 env: dev
 image: ""
-federationSchemaPublishCommand: null
 serviceAccount: null
 
 autoscaling:
@@ -58,6 +57,24 @@ deployment:
         type: httpGet
         port: http
         path: /
+
+federationSchemaPublish:
+  command: null
+
+  # extra environment variables from ConfigMaps like
+  # envConfig;
+  #   <ENV_VAR_NAME>: <keyOfValueInConfigMap>
+  configMapEnv: {}
+
+  # extra environment variables from Secrets like
+  # envSecret;
+  #   <ENV_VAR_NAME>: <keyOfValueInSecret>
+  secretEnv: {}
+
+  # extra static environment variables like
+  # envVars;
+  #   <ENV_VAR_NAME>: <envVarValue>
+  staticEnv: {}
 
 service:
   enabled: true

--- a/charts/service/values.yaml
+++ b/charts/service/values.yaml
@@ -1,7 +1,6 @@
 ---
 env: dev
 image: ""
-port: 3000
 federationSchemaPublishCommand: null
 serviceAccount: null
 
@@ -20,6 +19,46 @@ monitoring:
 externalSecret:
   enabled: true
 
+deployment:
+  containers:
+    default:
+      resources:
+        requests:
+          cpu: 200m
+        limits:
+          memory: 700Mi
+
+      # extra environment variables from ConfigMaps like
+      # envConfig;
+      #   <ENV_VAR_NAME>: <keyOfValueInConfigMap>
+      configMapEnv: {}
+
+      # extra environment variables from Secrets like
+      # envSecret;
+      #   <ENV_VAR_NAME>: <keyOfValueInSecret>
+      secretEnv: {}
+
+      # extra static environment variables like
+      # envVars;
+      #   <ENV_VAR_NAME>: <envVarValue>
+      staticEnv: {}
+
+      ports:
+        http: 3000
+
+      startupProbe:
+        failureThreshold: 30
+        period: 3
+        type: httpGet
+        port: http
+        path: /
+
+      livenessProbe:
+        period: 10
+        type: httpGet
+        port: http
+        path: /
+
 service:
   enabled: true
   type: NodePort
@@ -28,35 +67,3 @@ ingress:
   enabled: false
   pathPrefix: null
   hostnames: []
-
-resources:
-  requests:
-    cpu: 200m
-  limits:
-    memory: 700Mi
-
-# extra environment variables from ConfigMaps like
-# envConfig;
-#   <ENV_VAR_NAME>: <keyOfValueInConfigMap>
-configMapEnv: {}
-
-# extra environment variables from Secrets like
-# envSecret;
-#   <ENV_VAR_NAME>: <keyOfValueInSecret>
-secretEnv: {}
-
-# extra static environment variables like
-# envVars;
-#   <ENV_VAR_NAME>: <envVarValue>
-staticEnv: {}
-
-startupProbe:
-  failureThreshold: 30
-  period: 3
-  type: httpGet
-  path: /
-
-livenessProbe:
-  period: 10
-  type: httpGet
-  path: /

--- a/charts/service/values.yaml
+++ b/charts/service/values.yaml
@@ -14,6 +14,7 @@ autoscaling:
 
 monitoring:
   enabled: false
+  port: http
 
 externalSecret:
   enabled: true


### PR DESCRIPTION
Bumped the chart version to 2.0.0 because this is a pretty big breaking change (chart is versioned so won't break until dependents try to update).

Moved a lot of chart values under `deployment.containers.default` to make it possible to add containers to the deployment pod.