### PR TITLE
Add middlewares configuration for ingressroute

### DIFF
--- a/charts/service/Chart.yaml
+++ b/charts/service/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: allstar-service
-version: 2.1.0
-appVersion: 2.1.0
+version: 2.2.0
+appVersion: 2.2.0

--- a/charts/service/templates/ingressroute.yaml
+++ b/charts/service/templates/ingressroute.yaml
@@ -17,6 +17,12 @@ spec:
       services:
         - name: {{ .Release.Name }}
           port: {{ .Values.port }}
+      {{- if .Values.ingress.middlewares }}
+      middlewares:
+        {{- range $middleware := .Values.ingress.middlewares }}
+        - name: {{ $middleware }}
+        {{- end }}
+      {{- end }}
   tls:
     secretName: "{{ .Release.Name }}-tls"
 {{- end }}

--- a/charts/service/values.yaml
+++ b/charts/service/values.yaml
@@ -85,3 +85,4 @@ ingress:
   enabled: false
   pathPrefix: null
   hostnames: []
+  middlewares: []


### PR DESCRIPTION
There's a traefik middleware defined in https://github.com/allstar-gaming-llc/infrastructure/blob/main/modules/eks/traefik_proxy/manifests/auth_middleware.yaml that ensures all requests are authenticated via Google OAuth before allowing traffic to a service. This makes it possible to use that middleware from this helm chart.