### PR TITLE
fix[vx-1182]: Add ability to scale on resources from a single container

### DIFF
--- a/charts/service/Chart.yaml
+++ b/charts/service/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: allstar-service
-version: 2.2.0
-appVersion: 2.2.0
+version: 2.3.0
+appVersion: 2.3.0

--- a/charts/service/templates/autoscaler.yaml
+++ b/charts/service/templates/autoscaler.yaml
@@ -12,15 +12,21 @@ spec:
   minReplicas: {{ .Values.autoscaling.replicas.min }}
   maxReplicas: {{ .Values.autoscaling.replicas.max }}
   metrics:
-    - type: Resource
+    - type: {{ empty .Values.autoscaling.container | ternary "Resource" "Container" }}
       resource:
         name: cpu
+        {{- if .Values.autoscaling.container }}
+        container: {{ .Values.autoscaling.container }}
+        {{- end }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.autoscaling.averageUtilization.cpu }}
-    - type: Resource
+    - type: {{ empty .Values.autoscaling.container | ternary "Resource" "Container" }}
       resource:
         name: memory
+        {{- if .Values.autoscaling.container }}
+        container: {{ .Values.autoscaling.container }}
+        {{- end }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.autoscaling.averageUtilization.memory }}


### PR DESCRIPTION
The default is to scale on resources across all containers in all pods. This includes metrics containers for beatles which artificially drives down consumption averages.