### PR TITLE
feat[vx-1703] Add opentelemetry service.name annotation to Deployment

### DIFF
--- a/charts/service/CHANGELOG.md
+++ b/charts/service/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.5.0] - 2025-07-04
+
+### Added
+
+- Added proper opentelemetry service name annotation to the `deployment`
+  so it gets picked up by loki.
+
 ## [2.4.0] - 2025-04-23
 
 ### Added

--- a/charts/service/Chart.yaml
+++ b/charts/service/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: allstar-service
-version: 2.4.0
-appVersion: 2.4.0
+version: 2.5.0
+appVersion: 2.5.0

--- a/charts/service/templates/deployment.yaml
+++ b/charts/service/templates/deployment.yaml
@@ -16,6 +16,8 @@ spec:
       service: {{ .Release.Name }}
   template:
     metadata:
+      annotations:
+        resource.opentelemetry.io/service.name: {{ .Release.Name }}
       labels:
         service: {{ .Release.Name }}
     spec:


### PR DESCRIPTION
Loki treats this annotation as the `service_name` label (falls back to pod container name but that's not great since we default the container name to `default`). 