### PR TITLE
feat: Add KEDA & NATS JetStream scaler support for event-driven autoscaling

### DIFF
--- a/SCALING.md
+++ b/SCALING.md
@@ -1,0 +1,176 @@
+# AllStar Service Scaling
+
+### Traditional Autoscaling (HPA)
+
+The chart supports traditional CPU and memory-based autoscaling:
+
+```yaml
+autoscaling:
+  enabled: true
+  replicas:
+    min: 2
+    max: 10
+  averageUtilization:
+    cpu: 80
+    memory: 80
+```
+
+### KEDA NATS JetStream Autoscaling
+
+For event-driven autoscaling based on NATS JetStream message lag:
+
+```yaml
+autoscaling:
+  enabled: false # Disable traditional HPA when using KEDA
+  keda:
+    enabled: true
+    natsJetstream:
+      enabled: true
+      natsServerMonitoringEndpoint: "nats.nats.svc.cluster.local:8222"
+      account: "$G"
+      stream: "mystream"
+      consumer: "pull_consumer"
+      lagThreshold: "10"
+      activationLagThreshold: "15"
+      useHttps: false
+      authentication:
+        enabled: true
+        triggerAuthenticationName: "my-nats-auth"
+```
+
+## NATS JetStream Authentication
+
+### Using Existing NATS Credentials
+
+If your pods already have NATS credentials via external secrets, KEDA can use the same credentials:
+
+```yaml
+autoscaling:
+  keda:
+    natsJetstream:
+      authentication:
+        enabled: true
+```
+
+This configuration tells KEDA to use the existing `{{ .Release.Name }}` secret with the `nats-credentials` key that your application already uses. The TriggerAuthentication will be automatically named `{{ .Release.Name }}-scaler-auth`.
+
+## Parameters
+
+| Parameter                           | Description                  | Default           |
+| ----------------------------------- | ---------------------------- | ----------------- |
+| `autoscaling.keda.enabled`          | Enable KEDA autoscaling      | `false`           |
+| `autoscaling.keda.namespace`        | Namespace for KEDA resources | Release namespace |
+| `autoscaling.keda.triggers`         | Array of KEDA triggers       | `[]`              |
+| `autoscaling.keda.triggers[*].type` | Trigger type                 | Required          |
+
+**NATS JetStream Trigger Parameters:**
+| Parameter | Description | Default |
+| ---------------------------------- | --------------------------------- | ---------------------------------- |
+| `type` | Must be `nats-jetstream` | Required |
+| `natsServerUrl` | NATS server URL (from staticEnv) | `""` |
+| `natsServerMonitoringEndpoint` | NATS monitoring endpoint | `nats.nats.svc.cluster.local:8222` |
+| `account` | NATS account name | `$G` |
+| `stream` | JetStream stream name | `mystream` |
+| `consumer` | Consumer name | `pull_consumer` |
+| `lagThreshold` | Message lag threshold for scaling | `10` |
+| `activationLagThreshold` | Lag threshold to activate scaler | `15` |
+| `useHttps` | Use HTTPS for NATS endpoint | `false` |
+| `authentication.enabled` | Enable NATS authentication | `false` |
+
+## Examples
+
+### Basic KEDA NATS JetStream Setup
+
+```yaml
+autoscaling:
+  keda:
+    enabled: true
+    triggers:
+      - type: nats-jetstream
+        # Use existing NATS_SERVERS from staticEnv
+        natsServerUrl: "tls://aws.cloud.ngs.global"
+        stream: "orders"
+        consumer: "order-processor"
+        lagThreshold: "5"
+```
+
+### Complete Example with Existing Credentials
+
+```yaml
+autoscaling:
+  keda:
+    enabled: true
+    triggers:
+      - type: nats-jetstream
+        natsServerMonitoringEndpoint: "nats.example.com:8222"
+        account: "PROD"
+        stream: "orders"
+        consumer: "order-processor"
+        lagThreshold: "10"
+        activationLagThreshold: "20"
+        useHttps: true
+        authentication:
+          enabled: true
+```
+
+This uses the existing `orders-processor` secret with the `nats-credentials` key that your application already uses.
+
+### Using Existing NATS Server Configuration
+
+If your pods already have `NATS_SERVERS` configured in `staticEnv`, you can use the same URL:
+
+```yaml
+autoscaling:
+  keda:
+    enabled: true
+    triggers:
+      - type: nats-jetstream
+        natsServerUrl: "tls://aws.cloud.ngs.global" # From your staticEnv
+        # KEDA will derive monitoring endpoint: aws.cloud.ngs.global:8222
+        account: "PROD"
+        stream: "orders"
+        consumer: "order-processor"
+        lagThreshold: "10"
+        authentication:
+          enabled: true
+```
+
+### Multiple Triggers Example
+
+You can combine multiple triggers for more complex scaling scenarios:
+
+```yaml
+autoscaling:
+  keda:
+    enabled: true
+    triggers:
+      - type: nats-jetstream
+        natsServerUrl: "tls://aws.cloud.ngs.global"
+        stream: "orders"
+        consumer: "order-processor"
+        lagThreshold: "10"
+        authentication:
+          enabled: true
+      - type: cpu
+        metadata:
+          type: Utilization
+          value: "80"
+      - type: memory
+        metadata:
+          type: Utilization
+          value: "80"
+```
+
+## Troubleshooting
+
+1. **KEDA not scaling**: Check that KEDA is installed and running in your cluster
+2. **NATS connection issues**: Verify the NATS server monitoring endpoint is accessible
+3. **Authentication failures**: Ensure the existing secret contains valid NATS credentials
+4. **No metrics available**: Check that JetStream is enabled on your NATS server
+5. **Secret access issues**: Verify KEDA can access the secret in the same namespace
+
+## Resources
+
+- [KEDA Documentation](https://keda.sh/)
+- [NATS JetStream Scaler](https://keda.sh/docs/2.17/scalers/nats-jetstream/)
+- [NATS Documentation](https://docs.nats.io/)

--- a/charts/service/CHANGELOG.md
+++ b/charts/service/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.0] - 2025-09-24
+
+### Added
+
+- Added KEDA NATS JetStream scaler support with event-driven autoscaling
+
 ## [2.5.0] - 2025-07-04
 
 ### Added

--- a/charts/service/Chart.yaml
+++ b/charts/service/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: allstar-service
-version: 2.5.0
-appVersion: 2.5.0
+version: 2.6.0
+appVersion: 2.6.0

--- a/charts/service/templates/autoscaler.yaml
+++ b/charts/service/templates/autoscaler.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.autoscaling.enabled }}
+{{- if and .Values.autoscaling.enabled (not (and .Values.autoscaling.keda.enabled .Values.autoscaling.keda.triggers)) }}
 ---
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler

--- a/charts/service/templates/scaledobject.yaml
+++ b/charts/service/templates/scaledobject.yaml
@@ -1,0 +1,41 @@
+{{- if and .Values.autoscaling.keda.enabled .Values.autoscaling.keda.triggers }}
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: {{ .Release.Name }}-keda
+  namespace: {{ .Values.autoscaling.keda.namespace | default .Release.Namespace }}
+spec:
+  scaleTargetRef:
+    name: {{ .Release.Name }}
+  minReplicaCount: {{ .Values.autoscaling.replicas.min }}
+  maxReplicaCount: {{ .Values.autoscaling.replicas.max }}
+  triggers:
+  {{- range .Values.autoscaling.keda.triggers }}
+  - type: {{ .type }}
+    metadata:
+      {{- if eq .type "nats-jetstream" }}
+        {{- $monitoringEndpoint := .natsServerMonitoringEndpoint }}
+        {{- if .natsServerUrl }}
+          {{- $natsUrl := .natsServerUrl }}
+          {{- $monitoringEndpoint = printf "%s:8222" (trimPrefix "tls://" (trimPrefix "nats://" $natsUrl)) }}
+        {{- end }}
+        natsServerMonitoringEndpoint: "{{ $monitoringEndpoint }}"
+        account: "{{ .account }}"
+        stream: "{{ .stream }}"
+        consumer: "{{ .consumer }}"
+        lagThreshold: "{{ .lagThreshold }}"
+        {{- if .activationLagThreshold }}
+        activationLagThreshold: "{{ .activationLagThreshold }}"
+        {{- end }}
+        useHttps: "{{ .useHttps }}"
+        {{- if .authentication.enabled }}
+        credentials: "{{ $.Release.Name }}-scaler-auth-creds"
+        {{- end }}
+      {{- end }}
+    {{- if and (eq .type "nats-jetstream") .authentication.enabled }}
+    authenticationRef:
+      name: {{ $.Release.Name }}-scaler-auth
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/service/templates/triggerauthentication.yaml
+++ b/charts/service/templates/triggerauthentication.yaml
@@ -1,0 +1,13 @@
+{{- if and .Values.autoscaling.keda.enabled .Values.autoscaling.keda.triggers }}
+---
+apiVersion: keda.sh/v1alpha1
+kind: TriggerAuthentication
+metadata:
+  name: {{ .Release.Name }}-scaler-auth
+  namespace: {{ .Values.autoscaling.keda.namespace | default .Release.Namespace }}
+spec:
+  secretTargetRef:
+  - parameter: credentials
+    name: {{ .Release.Name }}
+    key: nats-credentials
+{{- end }}

--- a/charts/service/values.yaml
+++ b/charts/service/values.yaml
@@ -11,6 +11,8 @@ autoscaling:
   averageUtilization:
     cpu: 80
     memory: 80
+  keda:
+    enabled: false
 
 monitoring:
   enabled: false


### PR DESCRIPTION
##  **KEDA NATS JetStream Scaler Implementation**

### **Summary**
This PR adds KEDA support with NATS JetStream scaler to the chart. This enables  autoscaling based on NATS JetStream message queue lag.

### **Key Features Added**
**KEDA NATS JetStream Scaler**: Event-driven scaling based on JetStream message lag  
**Extensible Trigger System**: Configurable triggers array supporting multiple scaler types  
**Existing Infrastructure Integration**: Leverages existing NATS credentials and server configs  
**Automatic Authentication**: Uses existing external secrets for NATS authentication  
**Multiple Trigger Support**: Can combine NATS JetStream with CPU/memory triggers  

### **Prerequisites**
**⚠️ Must install KEDA on the Kubernetes cluster first:**
```bash
# Install KEDA using Helm
helm repo add kedacore https://kedacore.github.io/charts
helm repo update
helm install keda kedacore/keda --namespace keda --create-namespace
```

I have not done this yet, awaiting feedback before I do ☺️

### **Usage Example**
```yaml
autoscaling:
  keda:
    enabled: true
    triggers:
    - type: nats-jetstream
      natsServerUrl: "tls://aws.cloud.ngs.global"  # From existing staticEnv
      stream: "orders"
      consumer: "order-processor"
      lagThreshold: "10"
      authentication:
        enabled: true  # Uses existing external secret
```
---

**Notes**: 
- The implementation will gracefully fall back to traditional HPA autoscaling if KEDA triggers are not configured.
- @rosscooperman I am not 100% sure the **_triggerauthentication_** chart will be able to get to secrets, this was a little difficult to track down any info on concrete docs. 

