### PR TITLE
fix[] Disable replica setting by helm when there's an HPA

### DIFF
--- a/charts/service/CHANGELOG.md
+++ b/charts/service/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.5.1] - 2025-10-03
+
+### Fixed
+
+- Disabled setting replicas when autoscaling is turned on
+
 ## [2.5.0] - 2025-07-04
 
 ### Added

--- a/charts/service/CHANGELOG.md
+++ b/charts/service/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Disabled setting replicas when autoscaling is turned on
+- Disabled setting replicas when `autoscaling.enabled` true
 
 ## [2.6.0] - 2025-09-24
 

--- a/charts/service/Chart.yaml
+++ b/charts/service/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: allstar-service
-version: 2.5.0
-appVersion: 2.5.0
+version: 2.5.1
+appVersion: 2.5.1

--- a/charts/service/templates/deployment.yaml
+++ b/charts/service/templates/deployment.yaml
@@ -4,12 +4,14 @@ kind: Deployment
 metadata:
   name: {{ .Release.Name }}
 spec:
+  {{- if not .Values.autoscaling.enabled }}
   {{- if .Values.deployment.replicas }}
   replicas: {{ .Values.deployment.replicas }}
   {{- else if eq .Values.env "prod" }}
   replicas: 2
   {{- else }}
   replicas: 1
+  {{- end }}
   {{- end }}
   selector:
     matchLabels:


### PR DESCRIPTION
Without this every deploy scales down to the specified # of replicas and takes awhile for the HPA to scale us back up.